### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Stelzi79/86ee283c-8bae-4522-88a3-a2ae9df3b9e3/a66164b5-f82c-425a-bb13-805393780a58/_apis/work/boardbadge/eb1b314e-7541-42f7-b5f5-ea0b912c906b)](https://dev.azure.com/Stelzi79/86ee283c-8bae-4522-88a3-a2ae9df3b9e3/_boards/board/t/a66164b5-f82c-425a-bb13-805393780a58/Microsoft.RequirementCategory)
 # Akka-Diagrams
 
 A Nuget Library to a dotnet global tool to generate diagrams from a [Akka.Net](https://getakka.net/index.html) Actor system.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#46](https://dev.azure.com/Stelzi79/86ee283c-8bae-4522-88a3-a2ae9df3b9e3/_workitems/edit/46). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.